### PR TITLE
Declare nullable parameter types explicitly

### DIFF
--- a/src/Codeception/Module/Doctrine.php
+++ b/src/Codeception/Module/Doctrine.php
@@ -192,7 +192,7 @@ EOF;
         return [DoctrineProvider::class => $this->dependencyMessage];
     }
 
-    public function _inject(DoctrineProvider $dependentModule = null): void
+    public function _inject(?DoctrineProvider $dependentModule = null): void
     {
         $this->dependentModule = $dependentModule;
     }


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types deprecates implicitly nullable parameter types in PHP 8.4