### PR TITLE
Remove Reflection*::setAccessible() calls

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,7 +8,6 @@ parameters:
         - tests/data/doctrine_fixtures/TestFixture1.php
         - tests/data/doctrine_fixtures/TestFixture2.php
         - tests/_support/UnitTester.php
-  checkMissingIterableValueType: false
   reportUnmatchedIgnoredErrors: true
   ignoreErrors:
       - path: tests/
@@ -21,3 +20,4 @@ parameters:
         message: '#Method \S+ has no return type specified#'
       - path: tests/
         message: '#(?:Method|Property) .+ with generic (?:interface|class) \S+ does not specify its types#'
+      - identifier: missingType.iterableValue

--- a/src/Codeception/Module/Doctrine.php
+++ b/src/Codeception/Module/Doctrine.php
@@ -299,7 +299,6 @@ EOF;
         $reflectedEm = new ReflectionClass($em);
         if ($reflectedEm->hasProperty('repositories')) {
             $property = $reflectedEm->getProperty('repositories');
-            $property->setAccessible(true);
             $property->setValue($em, []);
         }
         $this->em->clear();
@@ -401,13 +400,11 @@ EOF;
             //Support doctrine versions before 2.4.0
 
             $property = $reflectedEm->getProperty('repositories');
-            $property->setAccessible(true);
             $property->setValue($em, array_merge($property->getValue($em), [$className => $mock]));
         } elseif ($reflectedEm->hasProperty('repositoryFactory')) {
             //For doctrine 2.4.0+ versions
 
             $repositoryFactoryProperty = $reflectedEm->getProperty('repositoryFactory');
-            $repositoryFactoryProperty->setAccessible(true);
             $repositoryFactory = $repositoryFactoryProperty->getValue($em);
 
             $reflectedRepositoryFactory = new ReflectionClass($repositoryFactory);
@@ -419,7 +416,6 @@ EOF;
                 );
             } elseif ($reflectedRepositoryFactory->hasProperty('repositoryList')) {
                 $repositoryListProperty = $reflectedRepositoryFactory->getProperty('repositoryList');
-                $repositoryListProperty->setAccessible(true);
 
                 $repositoryHash = $em->getClassMetadata($className)->getName() . spl_object_id($em);
                 $repositoryListProperty->setValue(

--- a/src/Codeception/Util/ReflectionPropertyAccessor.php
+++ b/src/Codeception/Util/ReflectionPropertyAccessor.php
@@ -25,7 +25,6 @@ class ReflectionPropertyAccessor
             $reflectedEntity = new ReflectionClass($class);
             if ($reflectedEntity->hasProperty($field)) {
                 $property = $reflectedEntity->getProperty($field);
-                $property->setAccessible(true);
                 return $property->getValue($obj);
             }
             $class = get_parent_class($class);
@@ -62,7 +61,6 @@ class ReflectionPropertyAccessor
 
         foreach ($reflectedEntity->getProperties() as $property) {
             if (isset($data[$property->name])) {
-                $property->setAccessible(true);
                 $property->setValue($obj, $data[$property->name]);
             }
         }

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -81,17 +81,17 @@ final class DoctrineTest extends Unit
         $connection = DriverManager::getConnection(['driver' => $sqliteDriver, 'memory' => true]);
         
         if (version_compare(InstalledVersions::getVersion('doctrine/orm'), '3', '>=')) {
-            $this->em = new EntityManager(
-                $connection,
-                ORMSetup::createAttributeMetadataConfiguration([$dir], true)
-            );
+            $configuration = ORMSetup::createAttributeMetadataConfiguration([$dir], true);
         } else {
-            $this->em = new EntityManager(
-                $connection,
-                // @phpstan-ignore-next-line
-                ORMSetup::createAnnotationMetadataConfiguration([$dir], true)
-            );
+            // @phpstan-ignore-next-line
+            $configuration = ORMSetup::createAnnotationMetadataConfiguration([$dir], true);
         }
+
+        if (PHP_VERSION_ID >= 80400 && method_exists($configuration, 'enableNativeLazyObjects')) {
+            $configuration->enableNativeLazyObjects(true);
+        }
+
+        $this->em = new EntityManager($connection, $configuration);
 
         (new SchemaTool($this->em))->createSchema([
             $this->em->getClassMetadata(CompositePrimaryKeyEntity::class),


### PR DESCRIPTION
> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations

This package requires at least PHP 8.1.
Thus, the calls can be safely removed.

This PR is based on https://github.com/Codeception/module-doctrine/pull/45 which fixes the CI