### PR TITLE
Enable native lazy objects if possible to fix the CI when using symfony 8

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,7 +8,6 @@ parameters:
         - tests/data/doctrine_fixtures/TestFixture1.php
         - tests/data/doctrine_fixtures/TestFixture2.php
         - tests/_support/UnitTester.php
-  checkMissingIterableValueType: false
   reportUnmatchedIgnoredErrors: true
   ignoreErrors:
       - path: tests/
@@ -21,3 +20,4 @@ parameters:
         message: '#Method \S+ has no return type specified#'
       - path: tests/
         message: '#(?:Method|Property) .+ with generic (?:interface|class) \S+ does not specify its types#'
+      - identifier: missingType.iterableValue

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -81,17 +81,17 @@ final class DoctrineTest extends Unit
         $connection = DriverManager::getConnection(['driver' => $sqliteDriver, 'memory' => true]);
         
         if (version_compare(InstalledVersions::getVersion('doctrine/orm'), '3', '>=')) {
-            $this->em = new EntityManager(
-                $connection,
-                ORMSetup::createAttributeMetadataConfiguration([$dir], true)
-            );
+            $configuration = ORMSetup::createAttributeMetadataConfiguration([$dir], true);
         } else {
-            $this->em = new EntityManager(
-                $connection,
-                // @phpstan-ignore-next-line
-                ORMSetup::createAnnotationMetadataConfiguration([$dir], true)
-            );
+            // @phpstan-ignore-next-line
+            $configuration = ORMSetup::createAnnotationMetadataConfiguration([$dir], true);
         }
+
+        if (PHP_VERSION_ID >= 80400 && method_exists($configuration, 'enableNativeLazyObjects')) {
+            $configuration->enableNativeLazyObjects(true);
+        }
+
+        $this->em = new EntityManager($connection, $configuration);
 
         (new SchemaTool($this->em))->createSchema([
             $this->em->getClassMetadata(CompositePrimaryKeyEntity::class),


### PR DESCRIPTION
`LazyGhostTrait` is not available in symfony 8 anymore and thus the tests will fail if native lazy objects are not enabled in doctrine/orm.