### PR TITLE
Fix deprecation warnings in doctrine/collections:2.4

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,7 +8,6 @@ parameters:
         - tests/data/doctrine_fixtures/TestFixture1.php
         - tests/data/doctrine_fixtures/TestFixture2.php
         - tests/_support/UnitTester.php
-  checkMissingIterableValueType: false
   reportUnmatchedIgnoredErrors: true
   ignoreErrors:
       - path: tests/
@@ -21,3 +20,4 @@ parameters:
         message: '#Method \S+ has no return type specified#'
       - path: tests/
         message: '#(?:Method|Property) .+ with generic (?:interface|class) \S+ does not specify its types#'
+      - identifier: missingType.iterableValue

--- a/src/Codeception/Module/Doctrine.php
+++ b/src/Codeception/Module/Doctrine.php
@@ -1009,7 +1009,7 @@ EOF;
             } elseif ($val instanceof Criteria) {
                 $qb->addCriteria($val);
             } elseif ($val instanceof Expression) {
-                $qb->addCriteria(Criteria::create()->where($val));
+                $qb->addCriteria(Criteria::create(true)->where($val));
             } else {
                 $qb->andWhere(sprintf('%s.%s = ?%s', $alias, $key, $paramIndex));
                 $qb->setParameter($paramIndex, $val);

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -81,17 +81,17 @@ final class DoctrineTest extends Unit
         $connection = DriverManager::getConnection(['driver' => $sqliteDriver, 'memory' => true]);
         
         if (version_compare(InstalledVersions::getVersion('doctrine/orm'), '3', '>=')) {
-            $this->em = new EntityManager(
-                $connection,
-                ORMSetup::createAttributeMetadataConfiguration([$dir], true)
-            );
+            $configuration = ORMSetup::createAttributeMetadataConfiguration([$dir], true);
         } else {
-            $this->em = new EntityManager(
-                $connection,
-                // @phpstan-ignore-next-line
-                ORMSetup::createAnnotationMetadataConfiguration([$dir], true)
-            );
+            // @phpstan-ignore-next-line
+            $configuration = ORMSetup::createAnnotationMetadataConfiguration([$dir], true);
         }
+
+        if (PHP_VERSION_ID >= 80400 && method_exists($configuration, 'enableNativeLazyObjects')) {
+            $configuration->enableNativeLazyObjects(true);
+        }
+
+        $this->em = new EntityManager($connection, $configuration);
 
         (new SchemaTool($this->em))->createSchema([
             $this->em->getClassMetadata(CompositePrimaryKeyEntity::class),

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -258,17 +258,17 @@ final class DoctrineTest extends Unit
     {
         $this->module->haveInRepository(PlainEntity::class, ['name' => 'Test 1']);
         $this->module->seeInRepository(PlainEntity::class, [
-            Criteria::create()->where(
+            Criteria::create(true)->where(
                 Criteria::expr()->eq('name', 'Test 1')
             ),
         ]);
         $this->module->seeInRepository(PlainEntity::class, [
-            Criteria::create()->where(
+            Criteria::create(true)->where(
                 Criteria::expr()->contains('name', 'est')
             ),
         ]);
         $this->module->seeInRepository(PlainEntity::class, [
-            Criteria::create()->where(
+            Criteria::create(true)->where(
                 Criteria::expr()->in('name', ['Test 1'])
             ),
         ]);
@@ -303,7 +303,7 @@ final class DoctrineTest extends Unit
                 'c',
             ],
             array_map($getName, $this->module->grabEntitiesFromRepository(PlainEntity::class, [
-                Criteria::create()->orderBy(['name' => 'asc']),
+                Criteria::create(true)->orderBy(['name' => 'asc']),
             ]))
         );
 
@@ -314,7 +314,7 @@ final class DoctrineTest extends Unit
                 'a',
             ],
             array_map($getName, $this->module->grabEntitiesFromRepository(PlainEntity::class, [
-                Criteria::create()->orderBy(['name' => 'desc']),
+                Criteria::create(true)->orderBy(['name' => 'desc']),
             ]))
         );
     }


### PR DESCRIPTION
This PR is based on https://github.com/Codeception/module-doctrine/pull/45 which fixes the CI.

`doctrine/collections:2.4` triggers a deprecation warning if `$accessRawFieldValues` is not set explicitly (see https://github.com/doctrine/collections/pull/472).